### PR TITLE
Update developer single handbook design

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/cli.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/inc/cli.php
@@ -447,7 +447,6 @@ class DevHub_CLI {
 
 	protected static function add_ids_and_jumpto_links( $tag, $content ) {
 		$items = self::get_tags( $tag, $content );
-		$first = true;
 		$matches = array();
 		$replacements = array();
 
@@ -456,11 +455,6 @@ class DevHub_CLI {
 			$matches[] = $item[0];
 			$id = sanitize_title_with_dashes($item[2]);
 
-			if ( ! $first ) {
-				$replacement .= '<p class="toc-jump"><a href="#top">' . __( 'Top &uarr;', 'wporg' ) . '</a></p>';
-			} else {
-				$first = false;
-			}
 			$a11y_text      = sprintf( '<span class="screen-reader-text">%s</span>', $item[2] );
 			$anchor         = sprintf( '<a href="#%1$s" class="anchor"><span aria-hidden="true">#</span>%2$s</a>', $id, $a11y_text );
 			$replacement   .= sprintf( '<%1$s class="toc-heading" id="%2$s" tabindex="-1">%3$s %4$s</%1$s>', $tag, $id, $item[2], $anchor );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-developer/stylesheets/main.css
@@ -2329,6 +2329,16 @@ aside[id^="nav_menu"] .widget-title {
   border-top: none;
 }
 
+.single-handbook .devhub-wrap main h2 {
+    margin-top: 4rem;
+    border-bottom: 2px solid #333;
+}
+
+.single-handbook .devhub-wrap main h3 {
+    margin-top: 4rem;
+    border-bottom: 1px solid #333;
+}
+
 .single-handbook .handbook-name-container + #primary {
   padding-top: 5rem;
 }


### PR DESCRIPTION
Minor design updates to the developer handbook. The theme applies to all of DevHub, so the changes are targeted to just single-handbook which covers the documentation handbooks but does not apply to the code reference documentation.

## Deisgn Updates

- Add underline and padding to content headings
- Remove auto insert back to top

Example page: https://developer.wordpress.org/block-editor/

**Before:**


![handbook-before](https://user-images.githubusercontent.com/45363/115749705-3a8b9400-a34c-11eb-834c-74db3b6c03ba.png)

**After:**

![handbook-after](https://user-images.githubusercontent.com/45363/115749739-424b3880-a34c-11eb-8b37-1c84c37b4287.jpg)

